### PR TITLE
Fix issue with property hasEvaluation

### DIFF
--- a/development/changelog.md
+++ b/development/changelog.md
@@ -1,13 +1,28 @@
-# ChangeLog between fair4ml version 0.1.0 and version 0.1.1
+# ChangeLog between fair4ml version 0.0.1 and version 0.1.0
 
-### 28.08.2026. - Feedback from the community and issues:
+### 27.10.2024. - Feedback from the community:
 
 #### Changes in fair4ml:MLModel Properties:
-- fair4ml:hasEvaluation
-    - Adds mention to inverse property **fair4ml:evaluatedMLModel**
+- fair4ml:ethicalLegalSocial
+    - Split into **fair4ml:legal** and **fair4ml:ethicalSocial**
+- **fair4ml:hasEvaluation**
+    - New property! used to link an MLModel with its corresponding MLModelEvaluation
+- fair4ml:hasCO2eEmissions
+    - Edit in the definition: Amount of CO2 equivalent emissions produced by **training** the model.
+- fair4ml:modelCategory
+    - Edit in the definition: Category of this ML model (e.g., Supervised, Unsupervised, Semi-supervised, Reinforcement), learning architecture (e.g., CNN, **transformer**), underlying algorithm (e.g., logistic regression, random forest, **LLM**).
+- fair4ml:modelRisks
+    - Renamed to: **fair4ml:modelRisksBiasLimitations**
+- **fair4ml:codeSampleSnippet**
+    - New property! Designed to show illustrate how to use a model in code. 
 
-#### Changes in fair4ml:MLModelEvaluation Properties:
-- fair4ml:evaluatedMLModel
-    - Corrects typo in the inverse property, it was **fair4ml:evaluatedWith** now it is **fair4ml:hasEvaluation**
-- properties from schema.org
-    - Adds **license**
+## NEW type: fair4ml:MLModelEvaluation
+A MLModelEvaluation is an object that bundles the context of a model evaluation: dataset, metrics used, results obtained, software used, etc. A model may have more than one evaluation.
+
+#### New fair4ml:MLModelEvaluation Properties
+- fair4ml:evaluatedMLModel: MLModel evaluated with this evaluation. Reverse property: fair4ml:hasEvaluation
+- fair4ml:evaluationDataset: Dataset used for the evaluation
+- fair4ml:evaluationMetrics: Description of the metrics used for evaluating the ML model. 
+- fair4ml:evaluationResults: Summary of the results from the evaluation
+- fair4ml:evaluationSoftware: Code used to performed the evaluation
+- fair4ml:extrinsicEvaluation: Indicates whether this evaluation is extrinsic, i.e., done with an existing model, outside the model training scope, and with a totally unseen dataset. It could be done by third-parties or by the authors of the model.

--- a/development/changelog.md
+++ b/development/changelog.md
@@ -1,28 +1,13 @@
-# ChangeLog between fair4ml version 0.0.1 and version 0.1.0
+# ChangeLog between fair4ml version 0.1.0 and version 0.1.1
 
-### 27.10.2024. - Feedback from the community:
+### 28.08.2026. - Feedback from the community and issues:
 
 #### Changes in fair4ml:MLModel Properties:
-- fair4ml:ethicalLegalSocial
-    - Split into **fair4ml:legal** and **fair4ml:ethicalSocial**
-- **fair4ml:hasEvaluation**
-    - New property! used to link an MLModel with its corresponding MLModelEvaluation
-- fair4ml:hasCO2eEmissions
-    - Edit in the definition: Amount of CO2 equivalent emissions produced by **training** the model.
-- fair4ml:modelCategory
-    - Edit in the definition: Category of this ML model (e.g., Supervised, Unsupervised, Semi-supervised, Reinforcement), learning architecture (e.g., CNN, **transformer**), underlying algorithm (e.g., logistic regression, random forest, **LLM**).
-- fair4ml:modelRisks
-    - Renamed to: **fair4ml:modelRisksBiasLimitations**
-- **fair4ml:codeSampleSnippet**
-    - New property! Designed to show illustrate how to use a model in code. 
+- fair4ml:hasEvaluation
+    - Adds mention to inverse property **fair4ml:evaluatedMLModel**
 
-## NEW type: fair4ml:MLModelEvaluation
-A MLModelEvaluation is an object that bundles the context of a model evaluation: dataset, metrics used, results obtained, software used, etc. A model may have more than one evaluation.
-
-#### New fair4ml:MLModelEvaluation Properties
-- fair4ml:evaluatedMLModel: MLModel evaluated with this evaluation. Reverse property: fair4ml:hasEvaluation
-- fair4ml:evaluationDataset: Dataset used for the evaluation
-- fair4ml:evaluationMetrics: Description of the metrics used for evaluating the ML model. 
-- fair4ml:evaluationResults: Summary of the results from the evaluation
-- fair4ml:evaluationSoftware: Code used to performed the evaluation
-- fair4ml:extrinsicEvaluation: Indicates whether this evaluation is extrinsic, i.e., done with an existing model, outside the model training scope, and with a totally unseen dataset. It could be done by third-parties or by the authors of the model.
+#### Changes in fair4ml:MLModelEvaluation Properties:
+- fair4ml:evaluatedMLModel
+    - Corrects typo in the inverse property, it was **fair4ml:evaluatedWith** now it is **fair4ml:hasEvaluation**
+- properties from schema.org
+    - Adds **license**

--- a/development/fair4ml.jsonld
+++ b/development/fair4ml.jsonld
@@ -55,27 +55,27 @@
                "name": [
                     "FAIR4ML JSON-LD Context"
                ],
-               "version": "0.1.0",
+               "version": "0.1.1",
                "url": {
-                    "@id": "https://w3id.org/fair4ml/0.1.0"
+                    "@id": "https://w3id.org/fair4ml/0.1.1"
                },
                "schema:schemaVersion": {
                     "@id": "https://raw.githubusercontent.com/schemaorg/schemaorg/main/data/releases/26.0/schemaorg-all-http.jsonld"
                },
                "license": {
-                    "@id": "https://creativecommons.org/publicdomain/zero/1.0/"
+                    "@id": "https://creativecommons.org/licenses/by-sa/4.0/"
                },
                "owl:versionIRI": {
-                    "@id": "https://w3id.org/fair4ml/0.1.0"
+                    "@id": "https://w3id.org/fair4ml/0.1.1"
                },
-               "schema:releaseDate": "2024-16-04",
+               "schema:releaseDate": "2026-08-28",
                "schema:codeRepository": {
                     "@id": "https://github.com/RDA-FAIR4ML/FAIR4ML-schema"
                },
                "schema:author":[
                     {
                          "@type": "Person",
-                         "schema:name":"Leyla-Jael Castro"
+                         "schema:name":"Leyla Jael Castro"
                     },
                     {
                          "@type": "Person",
@@ -170,7 +170,7 @@
           {
                "@id": "fair4ml:hasEvaluation",
                "@type": "rdf:Property",
-               "rdfs:comment": "Relationship to point to an evaluation for the model. It may be an evaluation coming from the training process or with a totally unseen dataset used only for evaluation purposes (e.g., a benchmark, extrinsic validation).",
+               "rdfs:comment": "Relationship to point to an evaluation for the model. It may be an evaluation coming from the training process or with a totally unseen dataset used only for evaluation purposes (e.g., a benchmark, extrinsic validation). Inverse property: fair4ml:evaluatedMLModel",
                "rdfs:label": "has evaluation",
                "schema:domainIncludes": {
                     "@id": "fair4ml:MLModel"
@@ -348,7 +348,7 @@
           {
                "@id": "fair4ml:evaluatedMLModel",
                "@type": "rdf:Property",
-               "rdfs:comment": "MLModel evaluated with this evaluation. Reverse property: fair4ml:evaluatedWith.",
+               "rdfs:comment": "MLModel evaluated with this evaluation. Inverse property: fair4ml:hasEvaluation.",
                "rdfs:label": "evaluated machine learning model",
                "schema:domainIncludes": {
                     "@id": "fair4ml:MLModelEvaluation"

--- a/development/fair4ml.jsonld
+++ b/development/fair4ml.jsonld
@@ -348,7 +348,7 @@
           {
                "@id": "fair4ml:evaluatedMLModel",
                "@type": "rdf:Property",
-               "rdfs:comment": "MLModel evaluated with this evaluation. Reverse property: fair4ml:hasEvaluation.",
+               "rdfs:comment": "MLModel evaluated with this evaluation. Inverse property: fair4ml:hasEvaluation.",
                "rdfs:label": "evaluated machine learning model",
                "schema:domainIncludes": {
                     "@id": "fair4ml:MLModelEvaluation"

--- a/development/fair4ml.jsonld
+++ b/development/fair4ml.jsonld
@@ -55,9 +55,9 @@
                "name": [
                     "FAIR4ML JSON-LD Context"
                ],
-               "version": "0.1.1",
+               "version": "0.1.0",
                "url": {
-                    "@id": "https://w3id.org/fair4ml/0.1.1"
+                    "@id": "https://w3id.org/fair4ml/0.1.0"
                },
                "schema:schemaVersion": {
                     "@id": "https://raw.githubusercontent.com/schemaorg/schemaorg/main/data/releases/26.0/schemaorg-all-http.jsonld"
@@ -66,9 +66,9 @@
                     "@id": "https://creativecommons.org/licenses/by-sa/4.0/"
                },
                "owl:versionIRI": {
-                    "@id": "https://w3id.org/fair4ml/0.1.1"
+                    "@id": "https://w3id.org/fair4ml/0.1.0"
                },
-               "schema:releaseDate": "2026-08-28",
+               "schema:releaseDate": "2024-16-04",
                "schema:codeRepository": {
                     "@id": "https://github.com/RDA-FAIR4ML/FAIR4ML-schema"
                },

--- a/development/index.html
+++ b/development/index.html
@@ -46,7 +46,7 @@
                         
                     
                         
-                            <li>Daniel Garijo, <a href="https://www.upm.es/">Universidad Politï¿½cnica de Madrid</a></li>
+                            <li>Daniel Garijo, <a href="https://www.upm.es/">Universidad Politécnica de Madrid</a></li>
                         
                     
                         
@@ -54,7 +54,7 @@
                         
                     
                         
-                            <li>Jenifer Tabita Ciuciu-Kiss, <a href="https://www.upm.es/">Universidad Politï¿½cnica de Madrid</a></li>
+                            <li>Jenifer Tabita Ciuciu-Kiss, <a href="https://www.upm.es/">Universidad Politécnica de Madrid</a></li>
                         
                     
                         
@@ -162,199 +162,196 @@
                             
                         
 
-                <h4>fair4ml:MLModel new properties</h4>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#legal">fair4ml:legal</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Considerations with respect to legal aspects.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#ethicalSocial">fair4ml:ethicalSocial</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Considerations with respect to ethical and social aspects.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluatedOn">fair4ml:evaluatedOn</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Dataset used for evaluating the model. The dataset used for evaluation may not have been part of the train/test/validation (e.g., a benchmark, extrinsic validation).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#fineTunedFrom">fair4ml:fineTunedFrom</a></td>
-                                    <td>
-                                        
-                                            <a href="https://w3id.org/fair4ml#MLModel">fair4ml:MLModel</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Relationship to point to the source model used for fine tuning (if this model was fine-tuned from another one).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#hasCO2eEmissions">fair4ml:hasCO2eEmissions</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Amount of CO2 equivalent emissions produced by training the model. The unit should be included in the field (e.g., 10 tonnes).</td>
-                                </tr>
-
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#hasEvaluation">fair4ml:hasEvaluation</a></td>
-                                    <td>
-                                        
-                                            <a href="https://w3id.org/fair4ml#MLModelEvaluation">fair4ml:MLModelEvaluation</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Relationship to point to an evaluation for the model. It may be an evaluation coming from the training process or with a totally unseen dataset used only for evaluation purposes (e.g., a benchmark, extrinsic validation).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#intendedUse">fair4ml:intendedUse</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                            <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
-                                        
-                                            <a href="http://schema.org/URL">schema:URL</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Purpose and intended use stated to enable users to make a decision as to the suitability of this creative work (e.g., lab protocol, machine learning model, software) to their experimental problem or own use case.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#mlTask">fair4ml:mlTask</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                            <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">ML task addressed by this ML software or model (e.g., binary classification).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#modelCategory">fair4ml:modelCategory</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                            <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Category of this ML model (e.g., Supervised, Unsupervised, Semi-supervised, Reinforcement), learning architecture (e.g., CNN, transformer), underlying algorithm (e.g., logistic regression, random forest, LLM).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#modelRisksBiasLimitations">fair4ml:modelRisksBiasLimitations</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Description of the risks and biases of the model, in a human-readable manner.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#sharedBy">fair4ml:sharedBy</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Person">schema:Person</a><br/>
-                                        
-                                            <a href="http://schema.org/Organization">schema:Organization</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Person or Organization who shared the model online (e.g., uploading it to HuggingFace).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#testedOn">fair4ml:testedOn</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Link to the dataset used to test the model (following train/test/validation splits).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#trainedOn">fair4ml:trainedOn</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">AI-ready dataset (after pre-processing) used for the training and optimization of this ML model.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#usageInstructions">fair4ml:usageInstructions</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Description of the instructions needed to run the model (e.g., to do inference on a task). Code snippets may be used for illustration.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#codeSampleSnippet">fair4ml:codeSampleSnippet</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Code snippet with a usage example of the model.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#validatedOn">fair4ml:validatedOn</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Link to the dataset used to validate the model. Typically the training dataset is a separated set from the train/testing set.</td>
-                                </tr>
-                            
-                        </tbody>
-                    </table>
-                </div>
+                        <!--First new properties-->
+                        <h4>fair4ml:MLModel new properties</h4>                            
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#legal">fair4ml:legal</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Considerations with respect to legal aspects.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#ethicalSocial">fair4ml:ethicalSocial</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Considerations with respect to ethical and social aspects.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluatedOn">fair4ml:evaluatedOn</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Dataset used for evaluating the model. The dataset used for evaluation may not have been part of the train/test/validation (e.g., a benchmark, extrinsic validation).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#hasEvaluation">fair4ml:hasEvaluation</a></td>
+                                            <td>
+                                                
+                                                    <a href="https://w3id.org/fair4ml#MLModelEvaluation">fair4ml:MLModelEvaluation</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Relationship to point to an evaluation for the model. It may be an evaluation coming from the training process or with a totally unseen dataset used only for evaluation purposes (e.g., a benchmark, extrinsic validation). Inverse property: fair4ml:evaluatedMLModel</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#fineTunedFrom">fair4ml:fineTunedFrom</a></td>
+                                            <td>
+                                                
+                                                    <a href="https://w3id.org/fair4ml#MLModel">fair4ml:MLModel</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Relationship to point to the source model used for fine tuning (if this model was fine-tuned from another one).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#hasCO2eEmissions">fair4ml:hasCO2eEmissions</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Amount of CO2 equivalent emissions produced by training the model. The unit should be included in the field (e.g., 10 tonnes).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#intendedUse">fair4ml:intendedUse</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Purpose and intended use stated to enable users to make a decision as to the suitability of this creative work (e.g., lab protocol, machine learning model, software) to their experimental problem or own use case.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#mlTask">fair4ml:mlTask</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">ML task addressed by this ML software or model (e.g., binary classification).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#modelCategory">fair4ml:modelCategory</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Category of this ML model (e.g., Supervised, Unsupervised, Semi-supervised, Reinforcement), learning architecture (e.g., CNN, transformer), underlying algorithm (e.g., logistic regression, random forest, LLM).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#modelRisksBiasLimitations">fair4ml:modelRisksBiasLimitations</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Description of the risks and biases of the model, in a human-readable manner.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#sharedBy">fair4ml:sharedBy</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Person">schema:Person</a><br/>
+                                                
+                                                    <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Person or Organization who shared the model online (e.g., uploading it to HuggingFace).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#testedOn">fair4ml:testedOn</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Link to the dataset used to test the model (following train/test/validation splits).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#trainedOn">fair4ml:trainedOn</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">AI-ready dataset (after pre-processing) used for the training and optimization of this ML model.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#usageInstructions">fair4ml:usageInstructions</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Description of the instructions needed to run the model (e.g., to do inference on a task). Code snippets may be used for illustration.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#codeSampleSnippet">fair4ml:codeSampleSnippet</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Code snippet with a usage example of the model.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#validatedOn">fair4ml:validatedOn</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Link to the dataset used to validate the model. Typically the training dataset is a separated set from the train/testing set.</td>
+                                        </tr>
+                                    
+                                </tbody>
+                            </table>
+                        </div>
 
                         <!--Second schema.org properties-->
                         <h4>fair4ml:MLModel properties inherited from Schema.org</h4> 
@@ -903,72 +900,333 @@
                         
                             <a href="#MLModelEvaluation">fair4ml:MLModelEvaluation</a>
                             
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluatedMLModel">fair4ml:evaluatedMLModel</a></td>
-                                    <td>
-                                        
-                                            <a href="https://w3id.org/fair4ml#MLModel">fair4ml:MLModel</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">MLModel evaluated with this evaluation. Reverse property: fair4ml:hasEvaluation.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationDataset">fair4ml:evaluationDataset</a></td>
-                                    <td>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Dataset used for the evaluation.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationMetrics">fair4ml:evaluationMetrics</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                            <a href="http://schema.org/PropertyValue">schema:PropertyValue</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Description of the metrics used for evaluating the ML model. Example with Text:  ["Precision: 0.8", "Mean: 0.9"].  Example with PropertyValue:  [{minValue: 0.0, maxValue: 1.0, value: 0.8, measurementTechnique: "Precision"} ...]</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationResults">fair4ml:evaluationResults</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Summary of the results from the evaluation.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationSoftware">fair4ml:evaluationSoftware</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/SoftwareSourceCode">schema:SoftwareSourceCode</a><br/>
-                                        
-                                            <a href="http://schema.org/SoftwareApplication">schema:SoftwareApplication</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Code used to performed the evaluation.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#extrinsicEvaluation">fair4ml:extrinsicEvaluation</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Boolean">schema:Boolean</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Indicates whether this evaluation is extrinsic, i.e., done with an existing model, outside the model training scope, and with a totally unseen dataset. It could be done by third-parties or by the authors of the model.</td>
-                                </tr>
-                            
-                        </tbody>
-                    </table>
+                        
+
+                        <!--First new properties-->
+                        <h4>fair4ml:MLModelEvaluation new properties</h4>                            
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluatedMLModel">fair4ml:evaluatedMLModel</a></td>
+                                            <td>
+                                                
+                                                    <a href="https://w3id.org/fair4ml#MLModel">fair4ml:MLModel</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">MLModel evaluated with this evaluation. Inverse property: fair4ml:hasEvaluation.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationDataset">fair4ml:evaluationDataset</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Dataset used for the evaluation.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationMetrics">fair4ml:evaluationMetrics</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Description of the metrics used for evaluating the ML model. Example with Text:  ["Precision: 0.8", "Mean: 0.9"].  Example with PropertyValue:  [{minValue: 0.0, maxValue: 1.0, value: 0.8, measurementTechnique: "Precision"} ...]</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationResults">fair4ml:evaluationResults</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/PropertyValue">schema:PropertyValue</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Summary of the results from the evaluation.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationSoftware">fair4ml:evaluationSoftware</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/SoftwareSourceCode">schema:SoftwareSourceCode</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Code used to performed the evaluation.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#extrinsicEvaluation">fair4ml:extrinsicEvaluation</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Boolean">schema:Boolean</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Indicates whether this evaluation is extrinsic, i.e., done with an existing model, outside the model training scope, and with a totally unseen dataset. It could be done by third-parties or by the authors of the model.</td>
+                                        </tr>
+                                    
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <!--Second schema.org properties-->
+                        <h4>fair4ml:MLModelEvaluation properties inherited from Schema.org</h4> 
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/author">schema:author</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Person">schema:Person</a><br/>
+                                                
+                                                    <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/citation">schema:citation</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/dateCreated">schema:dateCreated</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Date">schema:Date</a><br/>
+                                                
+                                                    <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The date on which the CreativeWork was created or the item was added to a DataFeed.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/dateModified">schema:dateModified</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Date">schema:Date</a><br/>
+                                                
+                                                    <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/datePublished">schema:datePublished</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Date">schema:Date</a><br/>
+                                                
+                                                    <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Date of first publication or broadcast. For example the date a <a href="http://schema.org/CreativeWork" target="_blank">CreativeWork</a> was broadcast or a <a href="http://schema.org/Certification" target="_blank">Certification</a> was issued.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/description">schema:description</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/TextObject">schema:TextObject</a><br/>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A description of the item.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/funding">schema:funding</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Grant">schema:Grant</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A <a href="http://schema.org/Grant" target="_blank">Grant</a> that directly or indirectly provide funding or sponsorship for this item. See also <a href="http://schema.org/ownershipFundingInfo" target="_blank">ownershipFundingInfo</a>.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/identifier">schema:identifier</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/PropertyValue">schema:PropertyValue</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing" target="_blank">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.
+        </td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/inLanguage">schema:inLanguage</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/Language">schema:Language</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also <a href="http://schema.org/availableLanguage" target="_blank">availableLanguage</a>.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/keywords">schema:keywords</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Keywords or tags used to describe some item. Multiple textual entries in a keywords list are typically delimited by commas, or by repeating the property.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/license">schema:license</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A license document that applies to this content, typically indicated by URL.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/name">schema:name</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The name of the item.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/url">schema:url</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">URL of the item.</td>
+                                        </tr>
+                                    
+                                
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <!--Third CodeMeta properties-->
+                        <h4>fair4ml:MLModelEvaluation properties inherited from CodeMeta</h4> 
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/codemeta/referencePublication">codemeta:referencePublication</a></td>
+                                            <td>
+                                                
+                                                    <a href="h">schema:ScholarlyArticle</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">An academic publication related to the software.</td>
+                                        </tr>
+                                    
+                                
+                                </tbody>
+                            </table>
+                        </div>
+
+            
+                    
+                    
+                    <!--END every type-->
+                    
                 </div>
 
                 <p>To see a summary of the changes between this version and the previous one see the following

--- a/development/index.html
+++ b/development/index.html
@@ -46,7 +46,7 @@
                         
                     
                         
-                            <li>Daniel Garijo, <a href="https://www.upm.es/">Universidad Politécnica de Madrid</a></li>
+                            <li>Daniel Garijo, <a href="https://www.upm.es/">Universidad PolitÃ©cnica de Madrid</a></li>
                         
                     
                         
@@ -54,7 +54,7 @@
                         
                     
                         
-                            <li>Jenifer Tabita Ciuciu-Kiss, <a href="https://www.upm.es/">Universidad Politécnica de Madrid</a></li>
+                            <li>Jenifer Tabita Ciuciu-Kiss, <a href="https://www.upm.es/">Universidad PolitÃ©cnica de Madrid</a></li>
                         
                     
                         
@@ -103,7 +103,7 @@
                 
                     <li>codemeta: <a href="https://w3id.org/codemeta/" target="_blank" class="external" rel="noopener">https://w3id.org/codemeta/</a></li>
                 
-                    <li>fair4ml: <a href="https://w3id.org/fair4ml/" target="_blank" class="external" rel="noopener">https://w3id.org/fair4ml/</a></li>
+                    <li>fair4ml: <a href="https://w3id.org/fair4ml#" target="_blank" class="external" rel="noopener">https://w3id.org/fair4ml#</a></li>
                 
                     <li>cr: <a href="http://mlcommons.org/croissant/1.0" target="_blank" class="external" rel="noopener">http://mlcommons.org/croissant/1.0</a></li>
                 

--- a/development/index.html
+++ b/development/index.html
@@ -32,26 +32,53 @@
     <div class="container min-vh-100">
         <main id="main" class="my-5">
             <h1>FAIR4ML Metadata Schema</h1>
-            <img src="img/logo.png" alt="drawing" style="width:100px;"/>
-            <h5>Release date: 2024.10.27</h5>
+            <img src="img/logo.png" alt="drawing" style="width:100px;">
+            <h5>Release date: 2024.11.04</h5>
             <h5>Version: 0.1.0</h5>
             <h5>Status: Draft (under review)</h5>
-            <h5>This version URI: <a href="https://w3id.org/fair4ml/0.1.0">https://w3id.org/fair4ml/0.1.0</a></h5>
-            <h5>Pevious version: <a href="https://w3id.org/fair4ml/0.0.1">https://w3id.org/fair4ml/0.0.1</a></h5>
+            <h5>This version URI: <a href="https://w3id.org/fair4ml/0.0.1">https://w3id.org/fair4ml/0.0.1</a></h5>
             <h5>Latest version URI: <a href="https://w3id.org/fair4ml#">https://w3id.org/fair4ml#</a></h5>
-            <h5>Authors. The list of authors is not final! Please contribute to the discussion in <a href="https://github.com/RDA-FAIR4ML/FAIR4ML-schema" target="_blank">our GitHub repository</a> or <a href="https://docs.google.com/spreadsheets/d/16nU5zGPdqm07eEJscDwxF5wonOINuTanEBkszjtG10M/edit?usp=sharing">discussion spreadsheet</a></h5>
+            <h5>Authors (in alphabetical order). The list of authors is not final! Please contribute to the discussion in <a href="https://github.com/RDA-FAIR4ML/FAIR4ML-schema" target="_blank">our GitHub repository</a> or <a href="https://docs.google.com/spreadsheets/d/1J2Q7M7p_JO0lYkQQ-QtCJyi_DNe3gR4Aqk7BynK5jj4/edit?usp=sharing">discussion spreadsheet</a></h5>
                 <ul>
-                    <li>Leyla-Jael Castro, <a href="https://www.zbmed.de/en/">ZB MED</a></li>
-                    <li>Daniel Garijo, <a href="https://www.upm.es/">Universidad PolitÃ©cnica de Madrid</a></li>
-                    <li>Dietrich Rebholz-Schuhmann, <a href="https://www.zbmed.de/en/">ZB MED</a></li>
-                    <li>Dhwani Solanki, <a href="https://www.zbmed.de/en/">ZB MED</a></li>
-                    <li>Jenifer Tabita Ciuciu-Kiss, <a href="https://www.upm.es/">Universidad PolitÃ©cnica de Madrid</a></li>
-                    <li>Dan Katz, <a href="https://illinois.edu/">University of Illinois Urbana-Champaign</a></li>
-                    <li>Lars Eklund, <a href="https://www.uu.se/en/">Uppsala University</a></li>
-                    <li>Gnana Bharathy, <a href="https://ardc.edu.au/">Australian Research Data Commons</a></li>
-                    <li><a href="https://www.rd-alliance.org/groups/fair-machine-learning-fair4ml-ig/members/all-members/">Research Data Alliance FAIR4ML Task Force</a></li>
+                    
+                        
+                            <li>Leyla Jael Castro, <a href="https://www.zbmed.de/en/">ZB MED Information Centre for Life Sciences</a></li>
+                        
+                    
+                        
+                            <li>Daniel Garijo, <a href="https://www.upm.es/">Universidad Politécnica de Madrid</a></li>
+                        
+                    
+                        
+                            <li>Gnana Bharathy, <a href="https://ardc.edu.au/">Australian Research Data Commons</a></li>
+                        
+                    
+                        
+                            <li>Jenifer Tabita Ciuciu-Kiss, <a href="https://www.upm.es/">Universidad Politécnica de Madrid</a></li>
+                        
+                    
+                        
+                            <li>Lars Eklund, <a href="https://www.uu.se/en/">Uppsala University</a></li>
+                        
+                    
+                        
+                            <li>Daniel S. Katz, <a href="https://illinois.edu/">University of Illinois Urbana-Champaign</a></li>
+                        
+                    
+                        
+                            <li>Dietrich Rebholz-Schuhmann, <a href="https://www.zbmed.de/en/">ZB MED Information Centre for Life Sciences</a></li>
+                        
+                    
+                        
+                            <li>Dhwani Solanki, <a href="https://www.zbmed.de/en/">ZB MED Information Centre for Life Sciences</a></li>
+                        
+                    
+                        
+                            <li><a href="https://www.rd-alliance.org/groups/fair-machine-learning-fair4ml-ig/members/all-members/">Research Data Alliance FAIR4ML Task Force</a></li>
+                        
+                    
                 </ul>
-            <h5>License: <a href="https://creativecommons.org/publicdomain/zero/1.0" target="_blank"><img src="https://img.shields.io/badge/License-https://creativecommons.org/publicdomain/zero/1.0/-blue.svg" alt="https://creativecommons.org/publicdomain/zero/1.0"></a> </h5>
+            <h5>License: <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"><img src="https://img.shields.io/badge/License-CC_by_sa-blue.svg" alt="https://creativecommons.org/licenses/by-sa/4.0/"></a> </h5>
             <h5>Download: <a href="fair4ml.jsonld" target="_blank"><img src="https://img.shields.io/badge/Format-JSON_LD-blue.svg" alt="JSON-LD"></a> <a href="https://github.com/RDA-FAIR4ML/FAIR4ML-schema" target="_blank"><img src="img/github.svg" width="3%"></a> </h5>
             <hr/>
 
@@ -60,7 +87,7 @@
                 An increasing amount of machine learning models are produced and shared in the Web by research scientists, ML enthusiast and ML developers. In this document we introduce a <a href="http://schema.org">Schema.org</a> extension for creating machine-readable representations of trained Machine Learning models. The proposed vocabulary also reuses properties from <a href="https://w3id.org/codemeta">codemeta</a>, in order to point to the code repository associated with a model. The figure below shows a high-level overview of the main metadata fields used to describe an ML model. 
             </p>
             <p>
-                <img src="img/MLModel schema.drawio.png"/ width="50%" >
+                <img src="img/MLModel schema.drawio.svg"/ width="50%" >
             </p>
 
             <h4>Namespaces used in this document</h4>
@@ -76,9 +103,9 @@
                 
                     <li>codemeta: <a href="https://w3id.org/codemeta/" target="_blank" class="external" rel="noopener">https://w3id.org/codemeta/</a></li>
                 
-                    <li>fair4ml: <a href="https://w3id.org/fair4ml#" target="_blank" class="external" rel="noopener">https://w3id.org/fair4ml#</a></li>
+                    <li>fair4ml: <a href="https://w3id.org/fair4ml/" target="_blank" class="external" rel="noopener">https://w3id.org/fair4ml/</a></li>
                 
-                    <li>cr: <a href="http://mlcommons.org/croissant/" target="_blank" class="external" rel="noopener">http://mlcommons.org/croissant/</a></li>
+                    <li>cr: <a href="http://mlcommons.org/croissant/1.0" target="_blank" class="external" rel="noopener">http://mlcommons.org/croissant/1.0</a></li>
                 
             </ul>
 
@@ -86,8 +113,44 @@
 
                 <div class="tab-pane fade show active" id="nav-description" role="tabpanel" aria-labelledby="nav-description-tab">
                     <h3>Extending Schema.org hierarchy</h3>
-                    <p>This Profile extends the Schema.org hierarchy with two main classes: <a href="#MLModel">fair4ml:MLModel</a> and <a href="#MLModelEvaluation">fair4ml:MLModelEvaluation</a>:</p>
-                    <p>
+                    <p>This Profile extends the Schema.org hierarchy as follows:</p>
+                    <ul>
+                        
+                            <!--list of new classes and hierarchy-->
+                            <li>
+                                
+                                    <a href="http://schema.org/Thing">schema:Thing</a>
+                                    &gt;
+                                
+                                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a>
+                                    &gt;
+                                
+                                    <a href="#MLModel">fair4ml:MLModel</a>
+                                    
+                                
+                            </li>
+                        
+                            <!--list of new classes and hierarchy-->
+                            <li>
+                                
+                                    <a href="http://schema.org/Thing">schema:Thing</a>
+                                    &gt;
+                                
+                                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a>
+                                    &gt;
+                                
+                                    <a href="#MLModelEvaluation">fair4ml:MLModelEvaluation</a>
+                                    
+                                
+                            </li>
+                        
+                    </ul>  
+                    <hr />
+
+                    <!--START every type-->
+                    
+                        <!--list of elements in each new class-->
+                        <h3 id="MLModel">Class fair4ml:MLModel</h3>
                         
                             <a href="http://schema.org/Thing">schema:Thing</a>
                             &gt;
@@ -95,944 +158,1087 @@
                             <a href="http://schema.org/CreativeWork">schema:CreativeWork</a>
                             &gt;
                         
-                            <a href="https://w3id.org/fair4ml#MLModel">fair4ml:MLModel</a>
+                            <a href="#MLModel">fair4ml:MLModel</a>
                             
                         
-                    </p>
-                    <hr />
-                </div>
-                
-                <h3 id="MLModel">fair4ml:MLModel</h3>
-                <p>Concept that represents a Machine Learning Model to describe with metadata. The model can be of any category (e.g., Language Model, SVC, etc.).</p>
 
-                <h4>fair4ml:MLModel new properties</h4>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#legal">fair4ml:legal</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Considerations with respect to legal aspects.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#ethicalSocial">fair4ml:ethicalSocial</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Considerations with respect to ethical and social aspects.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluatedOn">fair4ml:evaluatedOn</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Dataset used for evaluating the model. The dataset used for evaluation may not have been part of the train/test/validation (e.g., a benchmark, extrinsic validation).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#fineTunedFrom">fair4ml:fineTunedFrom</a></td>
-                                    <td>
-                                        
-                                            <a href="https://w3id.org/fair4ml#MLModel">fair4ml:MLModel</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Relationship to point to the source model used for fine tuning (if this model was fine-tuned from another one).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#hasCO2eEmissions">fair4ml:hasCO2eEmissions</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Amount of CO2 equivalent emissions produced by training the model. The unit should be included in the field (e.g., 10 tonnes).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#intendedUse">fair4ml:intendedUse</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                            <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
-                                        
-                                            <a href="http://schema.org/URL">schema:URL</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Purpose and intended use stated to enable users to make a decision as to the suitability of this creative work (e.g., lab protocol, machine learning model, software) to their experimental problem or own use case.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#mlTask">fair4ml:mlTask</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                            <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">ML task addressed by this ML software or model (e.g., binary classification).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#modelCategory">fair4ml:modelCategory</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                            <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Category of this ML model (e.g., Supervised, Unsupervised, Semi-supervised, Reinforcement), learning architecture (e.g., CNN, transformer), underlying algorithm (e.g., logistic regression, random forest, LLM).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#modelRisksBiasLimitations">fair4ml:modelRisksBiasLimitations</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Description of the risks and biases of the model, in a human-readable manner.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#sharedBy">fair4ml:sharedBy</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Person">schema:Person</a><br/>
-                                        
-                                            <a href="http://schema.org/Organization">schema:Organization</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Person or Organization who shared the model online (e.g., uploading it to HuggingFace).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#testedOn">fair4ml:testedOn</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Link to the dataset used to test the model (following train/test/validation splits).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#trainedOn">fair4ml:trainedOn</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">AI-ready dataset (after pre-processing) used for the training and optimization of this ML model.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#usageInstructions">fair4ml:usageInstructions</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Description of the instructions needed to run the model (e.g., to do inference on a task). Code snippets may be used for illustration.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#codeSampleSnippet">fair4ml:codeSampleSnippet</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Code snippet with a usage example of the model.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#validatedOn">fair4ml:validatedOn</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Link to the dataset used to validate the model. Typically the training dataset is a separated set from the train/testing set.</td>
-                                </tr>
-                            
-                        </tbody>
-                    </table>
-                </div>
+                        <!--First new properties-->
+                        <h4>fair4ml:MLModel new properties</h4>                            
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#legal">fair4ml:legal</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Considerations with respect to legal aspects.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#ethicalSocial">fair4ml:ethicalSocial</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Considerations with respect to ethical and social aspects.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluatedOn">fair4ml:evaluatedOn</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Dataset used for evaluating the model. The dataset used for evaluation may not have been part of the train/test/validation (e.g., a benchmark, extrinsic validation).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#hasEvaluation">fair4ml:hasEvaluation</a></td>
+                                            <td>
+                                                
+                                                    <a href="https://w3id.org/fair4ml#MLModelEvaluation">fair4ml:MLModelEvaluation</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Relationship to point to an evaluation for the model. It may be an evaluation coming from the training process or with a totally unseen dataset used only for evaluation purposes (e.g., a benchmark, extrinsic validation). Inverse property: fair4ml:evaluatedMLModel</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#fineTunedFrom">fair4ml:fineTunedFrom</a></td>
+                                            <td>
+                                                
+                                                    <a href="https://w3id.org/fair4ml#MLModel">fair4ml:MLModel</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Relationship to point to the source model used for fine tuning (if this model was fine-tuned from another one).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#hasCO2eEmissions">fair4ml:hasCO2eEmissions</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Amount of CO2 equivalent emissions produced by training the model. The unit should be included in the field (e.g., 10 tonnes).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#intendedUse">fair4ml:intendedUse</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Purpose and intended use stated to enable users to make a decision as to the suitability of this creative work (e.g., lab protocol, machine learning model, software) to their experimental problem or own use case.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#mlTask">fair4ml:mlTask</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">ML task addressed by this ML software or model (e.g., binary classification).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#modelCategory">fair4ml:modelCategory</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Category of this ML model (e.g., Supervised, Unsupervised, Semi-supervised, Reinforcement), learning architecture (e.g., CNN, transformer), underlying algorithm (e.g., logistic regression, random forest, LLM).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#modelRisksBiasLimitations">fair4ml:modelRisksBiasLimitations</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Description of the risks and biases of the model, in a human-readable manner.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#sharedBy">fair4ml:sharedBy</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Person">schema:Person</a><br/>
+                                                
+                                                    <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Person or Organization who shared the model online (e.g., uploading it to HuggingFace).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#testedOn">fair4ml:testedOn</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Link to the dataset used to test the model (following train/test/validation splits).</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#trainedOn">fair4ml:trainedOn</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Dataset">schema:Dataset</a><br/>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">AI-ready dataset (after pre-processing) used for the training and optimization of this ML model.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#usageInstructions">fair4ml:usageInstructions</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Description of the instructions needed to run the model (e.g., to do inference on a task). Code snippets may be used for illustration.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#codeSampleSnippet">fair4ml:codeSampleSnippet</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Code snippet with a usage example of the model.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#validatedOn">fair4ml:validatedOn</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Link to the dataset used to validate the model. Typically the training dataset is a separated set from the train/testing set.</td>
+                                        </tr>
+                                    
+                                </tbody>
+                            </table>
+                        </div>
 
-                
-
-
-                <!-- <h3>Schema.org Profiles</h3>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Profiles</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        
-                        </tbody>
-                    </table>
-                </div> -->
-
-                <h4>MLModel: properties inherited from Schema.org</h4>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/archivedAt">schema:archivedAt</a></td>
-                                <td>
+                        <!--Second schema.org properties-->
+                        <h4>fair4ml:MLModel properties inherited from Schema.org</h4> 
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/archivedAt">schema:archivedAt</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/WebPage">schema:WebPage</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Indicates a page or other link involved in archival of a <a href="http://schema.org/CreativeWork" target="_blank">CreativeWork</a>. In the case of <a href="http://schema.org/MediaReview" target="_blank">MediaReview</a>, the items in a <a href="http://schema.org/MediaReviewItem" target="_blank">MediaReviewItem</a> may often become inaccessible, but be archived by archival, journalistic, activist, or law enforcement organizations. In such cases, the referenced page may not directly publish the content.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/WebPage">schema:WebPage</a><br/>
+                                  
+                                      
                                     
-                                </td>
-                                <td class="description-column">Indicates a page or other link involved in archival of a <a href="http://schema.org/CreativeWork" target="_blank">CreativeWork</a>. In the case of <a href="http://schema.org/MediaReview" target="_blank">MediaReview</a>, the items in a <a href="http://schema.org/MediaReviewItem" target="_blank">MediaReviewItem</a> may often become inaccessible, but be archived by archival, journalistic, activist, or law enforcement organizations. In such cases, the referenced page may not directly publish the content.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/author">schema:author</a></td>
-                                <td>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/author">schema:author</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Person">schema:Person</a><br/>
+                                                
+                                                    <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/Person">schema:Person</a><br/>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/citation">schema:citation</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/citation">schema:citation</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/codeRepository">schema:codeRepository</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Link to the repository where the un-compiled, human readable code and related code is located (SVN, GitHub, CodePlex).</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
+                                  
+                                      
                                     
-                                </td>
-                                <td class="description-column">A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/codeRepository">schema:codeRepository</a></td>
-                                <td>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/conditionsOfAccess">schema:conditionsOfAccess</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an <a href="http://schema.org/ArchiveComponent" target="_blank">ArchiveComponent</a> held by an <a href="http://schema.org/ArchiveOrganization" target="_blank">ArchiveOrganization</a>. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.\n\nFor example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ". </td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
+                                  
+                                      
                                     
-                                </td>
-                                <td class="description-column">Link to the repository where the un-compiled, human readable code and related code is located (SVN, GitHub, CodePlex).</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/conditionsOfAccess">schema:conditionsOfAccess</a></td>
-                                <td>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/contributor">schema:contributor</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                                
+                                                    <a href="http://schema.org/Person">schema:Person</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A secondary contributor to the CreativeWork or Event.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                  
+                                      
                                     
-                                </td>
-                                <td class="description-column">Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an <a href="http://schema.org/ArchiveComponent" target="_blank">ArchiveComponent</a> held by an <a href="http://schema.org/ArchiveOrganization" target="_blank">ArchiveOrganization</a>. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.\n\nFor example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ". </td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/contributor">schema:contributor</a></td>
-                                <td>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/copyrightHolder">schema:copyrightHolder</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                                
+                                                    <a href="http://schema.org/Person">schema:Person</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The party holding the legal copyright to the CreativeWork.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Person">schema:Person</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/dateCreated">schema:dateCreated</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Date">schema:Date</a><br/>
+                                                
+                                                    <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The date on which the CreativeWork was created or the item was added to a DataFeed.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">A secondary contributor to the CreativeWork or Event.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/copyrightHolder">schema:copyrightHolder</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/dateModified">schema:dateModified</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Date">schema:Date</a><br/>
+                                                
+                                                    <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/Person">schema:Person</a><br/>
+                                  
+                                      
                                     
-                                </td>
-                                <td class="description-column">The party holding the legal copyright to the CreativeWork.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/dateCreated">schema:dateCreated</a></td>
-                                <td>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/datePublished">schema:datePublished</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Date">schema:Date</a><br/>
+                                                
+                                                    <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Date of first publication or broadcast. For example the date a <a href="http://schema.org/CreativeWork" target="_blank">CreativeWork</a> was broadcast or a <a href="http://schema.org/Certification" target="_blank">Certification</a> was issued.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/Date">schema:Date</a><br/>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/description">schema:description</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/TextObject">schema:TextObject</a><br/>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A description of the item.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">The date on which the CreativeWork was created or the item was added to a DataFeed.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/dateModified">schema:dateModified</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Date">schema:Date</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/discussionUrl">schema:discussionUrl</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A link to the page containing the comments of the CreativeWork.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                  
+                                      
                                     
-                                </td>
-                                <td class="description-column">The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/datePublished">schema:datePublished</a></td>
-                                <td>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/distribution">schema:distribution</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/DataDownload">schema:DataDownload</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A downloadable form of this dataset, at a specific location, in a specific format. This property can be repeated if different variations are available. There is no expectation that different downloadable distributions must contain exactly equivalent information (see also [DCAT](https://www.w3.org/TR/vocab-dcat-3/#Class:Distribution) on this point). Different distributions might include or exclude different subsets of the entire dataset, for example.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/Date">schema:Date</a><br/>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/funding">schema:funding</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Grant">schema:Grant</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A <a href="http://schema.org/Grant" target="_blank">Grant</a> that directly or indirectly provide funding or sponsorship for this item. See also <a href="http://schema.org/ownershipFundingInfo" target="_blank">ownershipFundingInfo</a>.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Date of first publication or broadcast. For example the date a <a href="http://schema.org/CreativeWork" target="_blank">CreativeWork</a> was broadcast or a <a href="http://schema.org/Certification" target="_blank">Certification</a> was issued.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/description">schema:description</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/TextObject">schema:TextObject</a><br/>
-                                    
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">A description of the item.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/discussionUrl">schema:discussionUrl</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">A link to the page containing the comments of the CreativeWork.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/distribution">schema:distribution</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/DataDownload">schema:DataDownload</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">A downloadable form of this dataset, at a specific location, in a specific format. This property can be repeated if different variations are available. There is no expectation that different downloadable distributions must contain exactly equivalent information (see also [DCAT](https://www.w3.org/TR/vocab-dcat-3/#Class:Distribution) on this point). Different distributions might include or exclude different subsets of the entire dataset, for example.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/funding">schema:funding</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Grant">schema:Grant</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">A <a href="http://schema.org/Grant" target="_blank">Grant</a> that directly or indirectly provide funding or sponsorship for this item. See also <a href="http://schema.org/ownershipFundingInfo" target="_blank">ownershipFundingInfo</a>.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/identifier">schema:identifier</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
-                                    
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
-                                    
-                                        <a href="http://schema.org/PropertyValue">schema:PropertyValue</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing" target="_blank">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/identifier">schema:identifier</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/PropertyValue">schema:PropertyValue</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing" target="_blank">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.
         </td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/inLanguage">schema:inLanguage</a></td>
-                                <td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Language">schema:Language</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/inLanguage">schema:inLanguage</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/Language">schema:Language</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also <a href="http://schema.org/availableLanguage" target="_blank">availableLanguage</a>.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also <a href="http://schema.org/availableLanguage" target="_blank">availableLanguage</a>.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/isAccessibleForFree">schema:isAccessibleForFree</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Boolean">schema:Boolean</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/isAccessibleForFree">schema:isAccessibleForFree</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Boolean">schema:Boolean</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A flag to signal that the item, event, or place is accessible for free.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">A flag to signal that the item, event, or place is accessible for free.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/keywords">schema:keywords</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/keywords">schema:keywords</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Keywords or tags used to describe some item. Multiple textual entries in a keywords list are typically delimited by commas, or by repeating the property.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/license">schema:license</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A license document that applies to this content, typically indicated by URL.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Keywords or tags used to describe some item. Multiple textual entries in a keywords list are typically delimited by commas, or by repeating the property.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/license">schema:license</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
-                                    
-                                        <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">A license document that applies to this content, typically indicated by URL.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/maintainer">schema:maintainer</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Organization">schema:Organization</a><br/>
-                                    
-                                        <a href="http://schema.org/Person">schema:Person</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">A maintainer of a <a href="http://schema.org/Dataset" target="_blank">Dataset</a>, software package (<a href="http://schema.org/SoftwareApplication" target="_blank">SoftwareApplication</a>), or other <a href="http://schema.org/Project" target="_blank">Project</a>. A maintainer is a <a href="http://schema.org/Person" target="_blank">Person</a> or <a href="http://schema.org/Organization" target="_blank">Organization</a> that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When maintainer is applied to a specific version of something e.g. a particular version or packaging of a <a href="http://schema.org/Dataset" target="_blank">Dataset</a>, it is always  possible that the upstream source has a different maintainer. The <a href="http://schema.org/isBasedOn" target="_blank">isBasedOn</a> property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/maintainer">schema:maintainer</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                                
+                                                    <a href="http://schema.org/Person">schema:Person</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A maintainer of a <a href="http://schema.org/Dataset" target="_blank">Dataset</a>, software package (<a href="http://schema.org/SoftwareApplication" target="_blank">SoftwareApplication</a>), or other <a href="http://schema.org/Project" target="_blank">Project</a>. A maintainer is a <a href="http://schema.org/Person" target="_blank">Person</a> or <a href="http://schema.org/Organization" target="_blank">Organization</a> that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When maintainer is applied to a specific version of something e.g. a particular version or packaging of a <a href="http://schema.org/Dataset" target="_blank">Dataset</a>, it is always  possible that the upstream source has a different maintainer. The <a href="http://schema.org/isBasedOn" target="_blank">isBasedOn</a> property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
       </td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/memoryRequirements">schema:memoryRequirements</a></td>
-                                <td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/memoryRequirements">schema:memoryRequirements</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Minimum memory requirements.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Minimum memory requirements.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/name">schema:name</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/name">schema:name</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The name of the item.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">The name of the item.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/operatingSystem">schema:operatingSystem</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/operatingSystem">schema:operatingSystem</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Operating systems supported (Windows 7, OS X 10.6, Android 1.6).</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Operating systems supported (Windows 7, OS X 10.6, Android 1.6).</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/processorRequirements">schema:processorRequirements</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/processorRequirements">schema:processorRequirements</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Processor architecture required to run the application (e.g. IA64).</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Processor architecture required to run the application (e.g. IA64).</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/releaseNotes">schema:releaseNotes</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/releaseNotes">schema:releaseNotes</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Description of what changed in this version.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
+                                  
+                                      
                                     
-                                </td>
-                                <td class="description-column">Description of what changed in this version.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/softwareHelp">schema:softwareHelp</a></td>
-                                <td>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/softwareHelp">schema:softwareHelp</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Software application help.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
+                                  
+                                      
                                     
-                                </td>
-                                <td class="description-column">Software application help.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/softwareRequirements">schema:softwareRequirements</a></td>
-                                <td>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/softwareRequirements">schema:softwareRequirements</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (examples: DirectX, Java or .NET runtime).</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/storageRequirements">schema:storageRequirements</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Storage requirements (free space required).</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (examples: DirectX, Java or .NET runtime).</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/storageRequirements">schema:storageRequirements</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/url">schema:url</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">URL of the item.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
+                                  
+                                      
                                     
-                                </td>
-                                <td class="description-column">Storage requirements (free space required).</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/url">schema:url</a></td>
-                                <td>
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/version">schema:version</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Number">schema:Number</a><br/>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The version of the CreativeWork embodied by a specified resource.</td>
+                                        </tr>
                                     
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">URL of the item.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/version">schema:version</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Number">schema:Number</a><br/>
-                                    
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">The version of the CreativeWork embodied by a specified resource.</td>
-                            </tr>
-                        
-                        </tbody>
-                    </table>
-                </div>
+                                
+                                </tbody>
+                            </table>
+                        </div>
 
-                <h4>MLModel: Properties inherited from CodeMeta </h4>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        
-                            <tr>
-                                <td class="property-column"><a href="https://w3id.org/codemeta/buildInstructions">codemeta:buildInstructions</a></td>
-                                <td>
+                        <!--Third CodeMeta properties-->
+                        <h4>fair4ml:MLModel properties inherited from CodeMeta</h4> 
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                  
+                                      
                                     
-                                        <a href="https://schema.org/URL">schema:URL</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/codemeta/buildInstructions">codemeta:buildInstructions</a></td>
+                                            <td>
+                                                
+                                                    <a href="h">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Link to installation instructions/documentation.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Link to installation instructions/documentation.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="https://w3id.org/codemeta/developmentStatus">codemeta:developmentStatus</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="https://schema.org/Text">schema:Text</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/codemeta/developmentStatus">codemeta:developmentStatus</a></td>
+                                            <td>
+                                                
+                                                    <a href="h">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Description of development status, e.g. Active, inactive, suspended. See repostatus.org .</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Description of development status, e.g. Active, inactive, suspended. See repostatus.org .</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="https://w3id.org/codemeta/issueTracker">codemeta:issueTracker</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="https://schema.org/URL">schema:URL</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/codemeta/issueTracker">codemeta:issueTracker</a></td>
+                                            <td>
+                                                
+                                                    <a href="h">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Link to software bug reporting or issue tracking system.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Link to software bug reporting or issue tracking system.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="https://w3id.org/codemeta/readme">codemeta:readme</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="https://schema.org/URL">schema:URL</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/codemeta/readme">codemeta:readme</a></td>
+                                            <td>
+                                                
+                                                    <a href="h">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Link to software Readme file.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">Link to software Readme file.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="https://w3id.org/codemeta/referencePublication">codemeta:referencePublication</a></td>
-                                <td>
+                                  
+                                      
                                     
-                                        <a href="https://schema.org/ScholarlyArticle">schema:ScholarlyArticle</a><br/>
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/codemeta/referencePublication">codemeta:referencePublication</a></td>
+                                            <td>
+                                                
+                                                    <a href="h">schema:ScholarlyArticle</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">An academic publication related to the software.</td>
+                                        </tr>
                                     
-                                </td>
-                                <td class="description-column">An academic publication related to the software.</td>
-                            </tr>
-                        
-                        </tbody>
-                    </table>
-                </div>
+                                
+                                </tbody>
+                            </table>
+                        </div>
 
-            <h3 id="MLModelEvaluation">fair4ml:MLModelEvaluation</h3>
-                <p>Evaluation associated with a model. It could be an evaluation coming from the training process or with a totally unseen dataset used only for evaluation purposes (e.g., a benchmark, extrinsic validation).</p>
-                <p>
-                        
-                    <a href="http://schema.org/Thing">schema:Thing</a>
-                    &gt;
-                
-                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a>
-                    &gt;
-                
-                    <a href="https://w3id.org/fair4ml#MLModelEvaluation">fair4ml:MLModelEvaluation</a>
+            
                     
-                
-                </p>
-                <hr />
-                
-                <h4>fair4ml:MLModelEvaluation new properties: </h4>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
+                    
+                        <!--list of elements in each new class-->
+                        <h3 id="MLModelEvaluation">Class fair4ml:MLModelEvaluation</h3>
+                        
+                            <a href="http://schema.org/Thing">schema:Thing</a>
+                            &gt;
+                        
+                            <a href="http://schema.org/CreativeWork">schema:CreativeWork</a>
+                            &gt;
+                        
+                            <a href="#MLModelEvaluation">fair4ml:MLModelEvaluation</a>
                             
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#hasEvaluation">fair4ml:hasEvaluation</a></td>
-                                    <td>
-                                        
-                                            <a href="https://w3id.org/fair4ml#MLModelEvaluation">fair4ml:MLModelEvaluation</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Relationship to point to the source model used for fine tuning (if this model was fine-tuned from another one).</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluatedMLModel">fair4ml:evaluatedMLModel</a></td>
-                                    <td>
-                                        
-                                            <a href="https://w3id.org/fair4ml#MLModel">fair4ml:MLModel</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">MLModel evaluated with this evaluation. Reverse property: fair4ml:evaluatedWith.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationDataset">fair4ml:evaluationDataset</a></td>
-                                    <td>
-                                        
-                                            <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Dataset used for the evaluation.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationMetrics">fair4ml:evaluationMetrics</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                            <a href="http://schema.org/PropertyValue">schema:PropertyValue</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Description of the metrics used for evaluating the ML model. Example with Text:  ["Precision: 0.8", "Mean: 0.9"].  Example with PropertyValue:  [{minValue: 0.0, maxValue: 1.0, value: 0.8, measurementTechnique: "Precision"} ...]</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationResults">fair4ml:evaluationResults</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Text">schema:Text</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Summary of the results from the evaluation.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationSoftware">fair4ml:evaluationSoftware</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/SoftwareSourceCode">schema:SoftwareSourceCode</a><br/>
-                                        
-                                            <a href="http://schema.org/SoftwareApplication">schema:SoftwareApplication</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Code used to performed the evaluation.</td>
-                                </tr>
-                            
-                                <tr>
-                                    <td class="property-column"><a href="https://w3id.org/fair4ml#extrinsicEvaluation">fair4ml:extrinsicEvaluation</a></td>
-                                    <td>
-                                        
-                                            <a href="http://schema.org/Boolean">schema:Boolean</a><br/>
-                                        
-                                    </td>
-                                    <td class="description-column">Indicates whether this evaluation is extrinsic, i.e., done with an existing model, outside the model training scope, and with a totally unseen dataset. It could be done by third-parties or by the authors of the model.</td>
-                                </tr>
-                            
-                        </tbody>
-                    </table>
+                        
+
+                        <!--First new properties-->
+                        <h4>fair4ml:MLModelEvaluation new properties</h4>                            
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluatedMLModel">fair4ml:evaluatedMLModel</a></td>
+                                            <td>
+                                                
+                                                    <a href="https://w3id.org/fair4ml#MLModel">fair4ml:MLModel</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">MLModel evaluated with this evaluation. Inverse property: fair4ml:hasEvaluation.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationDataset">fair4ml:evaluationDataset</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://mlcommons.org/croissant/1.0">cr:Dataset</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Dataset used for the evaluation.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationMetrics">fair4ml:evaluationMetrics</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Description of the metrics used for evaluating the ML model. Example with Text:  ["Precision: 0.8", "Mean: 0.9"].  Example with PropertyValue:  [{minValue: 0.0, maxValue: 1.0, value: 0.8, measurementTechnique: "Precision"} ...]</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationResults">fair4ml:evaluationResults</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/PropertyValue">schema:PropertyValue</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Summary of the results from the evaluation.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#evaluationSoftware">fair4ml:evaluationSoftware</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/SoftwareSourceCode">schema:SoftwareSourceCode</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Code used to performed the evaluation.</td>
+                                        </tr>
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/fair4ml#extrinsicEvaluation">fair4ml:extrinsicEvaluation</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Boolean">schema:Boolean</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Indicates whether this evaluation is extrinsic, i.e., done with an existing model, outside the model training scope, and with a totally unseen dataset. It could be done by third-parties or by the authors of the model.</td>
+                                        </tr>
+                                    
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <!--Second schema.org properties-->
+                        <h4>fair4ml:MLModelEvaluation properties inherited from Schema.org</h4> 
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/author">schema:author</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Person">schema:Person</a><br/>
+                                                
+                                                    <a href="http://schema.org/Organization">schema:Organization</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/citation">schema:citation</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/dateCreated">schema:dateCreated</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Date">schema:Date</a><br/>
+                                                
+                                                    <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The date on which the CreativeWork was created or the item was added to a DataFeed.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/dateModified">schema:dateModified</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Date">schema:Date</a><br/>
+                                                
+                                                    <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/datePublished">schema:datePublished</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Date">schema:Date</a><br/>
+                                                
+                                                    <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Date of first publication or broadcast. For example the date a <a href="http://schema.org/CreativeWork" target="_blank">CreativeWork</a> was broadcast or a <a href="http://schema.org/Certification" target="_blank">Certification</a> was issued.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/description">schema:description</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/TextObject">schema:TextObject</a><br/>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A description of the item.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/funding">schema:funding</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Grant">schema:Grant</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A <a href="http://schema.org/Grant" target="_blank">Grant</a> that directly or indirectly provide funding or sponsorship for this item. See also <a href="http://schema.org/ownershipFundingInfo" target="_blank">ownershipFundingInfo</a>.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/identifier">schema:identifier</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/PropertyValue">schema:PropertyValue</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing" target="_blank">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.
+        </td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/inLanguage">schema:inLanguage</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/Language">schema:Language</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also <a href="http://schema.org/availableLanguage" target="_blank">availableLanguage</a>.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/keywords">schema:keywords</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">Keywords or tags used to describe some item. Multiple textual entries in a keywords list are typically delimited by commas, or by repeating the property.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/license">schema:license</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                                    <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">A license document that applies to this content, typically indicated by URL.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/name">schema:name</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/Text">schema:Text</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">The name of the item.</td>
+                                        </tr>
+                                    
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="http://schema.org/url">schema:url</a></td>
+                                            <td>
+                                                
+                                                    <a href="http://schema.org/URL">schema:URL</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">URL of the item.</td>
+                                        </tr>
+                                    
+                                
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <!--Third CodeMeta properties-->
+                        <h4>fair4ml:MLModelEvaluation properties inherited from CodeMeta</h4> 
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                  
+                                      
+                                    
+                                        <tr>
+                                            <td class="property-column"><a href="https://w3id.org/codemeta/referencePublication">codemeta:referencePublication</a></td>
+                                            <td>
+                                                
+                                                    <a href="h">schema:ScholarlyArticle</a><br/>
+                                                
+                                            </td>
+                                            <td class="description-column">An academic publication related to the software.</td>
+                                        </tr>
+                                    
+                                
+                                </tbody>
+                            </table>
+                        </div>
+
+            
+                    
+                    
+                    <!--END every type-->
+                    
                 </div>
 
-                <h4>MLModelEvaluation: properties inherited from Schema.org</h4>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/author">schema:author</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Person">schema:Person</a><br/>
-                                    
-                                        <a href="http://schema.org/Organization">schema:Organization</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/citation">schema:citation</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
-                                    
-                                        <a href="http://schema.org/CreativeWork">schema:CreativeWork</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/dateCreated">schema:dateCreated</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Date">schema:Date</a><br/>
-                                    
-                                        <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">The date on which the CreativeWork was created or the item was added to a DataFeed.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/dateModified">schema:dateModified</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Date">schema:Date</a><br/>
-                                    
-                                        <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/datePublished">schema:datePublished</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Date">schema:Date</a><br/>
-                                    
-                                        <a href="http://schema.org/DateTime">schema:DateTime</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">Date of first publication or broadcast. For example the date a <a href="http://schema.org/CreativeWork" target="_blank">CreativeWork</a> was broadcast or a <a href="http://schema.org/Certification" target="_blank">Certification</a> was issued.</td>
-                            </tr>
-
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/description">schema:description</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/TextObject">schema:TextObject</a><br/>
-                                    
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">A description of the evaluation.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/funding">schema:funding</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Grant">schema:Grant</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">A <a href="http://schema.org/Grant" target="_blank">Grant</a> that directly or indirectly provide funding or sponsorship for this item. See also <a href="http://schema.org/ownershipFundingInfo" target="_blank">ownershipFundingInfo</a>.</td>
-                            </tr>
-
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/identifier">schema:identifier</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
-                                    
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
-                                    
-                                        <a href="http://schema.org/PropertyValue">schema:PropertyValue</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing" target="_blank">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.
-                                </td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/inLanguage">schema:inLanguage</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
-                                    
-                                        <a href="http://schema.org/Language">schema:Language</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also <a href="http://schema.org/availableLanguage" target="_blank">availableLanguage</a>.</td>
-                            </tr>
-
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/name">schema:name</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">The name of the item.</td>
-                            </tr>
-                        
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/keywords">schema:keywords</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/Text">schema:Text</a><br/>
-                                    
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
-                                    
-                                        <a href="http://schema.org/DefinedTerm">schema:DefinedTerm</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">Keywords or tags used to describe some item. Multiple textual entries in a keywords list are typically delimited by commas, or by repeating the property.</td>
-                            </tr>
-
-                            <tr>
-                                <td class="property-column"><a href="http://schema.org/url">schema:url</a></td>
-                                <td>
-                                    
-                                        <a href="http://schema.org/URL">schema:URL</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">URL of the item.</td>
-                            </tr>
-                        
-                        </tbody>
-                    </table>
-                </div>
-
-                <h4>MLModelEvaluation: Properties inherited from CodeMeta </h4>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        
-                            <tr>
-                                <td class="property-column"><a href="https://w3id.org/codemeta/referencePublication">codemeta:referencePublication</a></td>
-                                <td>
-                                    
-                                        <a href="https://schema.org/ScholarlyArticle">schema:ScholarlyArticle</a><br/>
-                                    
-                                </td>
-                                <td class="description-column">An academic publication related to the evaluation.</td>
-                            </tr>
-                        
-                        </tbody>
-                    </table>
-                </div>
+                <p>To see a summary of the changes between this version and the previous one see the following
+                    <a href="./changelog.md">changelog</a> </p>
                 
-                <p>To see a summary of the changes between this version and <a href="https://w3id.org/fair4ml/0.0.1">version 0.0.1</a> see the following <a href="changelog.md">changelog</a></p>
                 <p>If you spot any errors or omissions, please file an issue in our <a
                     href="https://github.com/RDA-FAIR4ML/FAIR4ML-schema" target="_blank">GitHub</a>.</p>
+            
+            </div>   
 
-
-            </div>
         </main>
     </div>
-
     <script src="/assets/js/clipboard.min.js"></script>
     <script src="/assets/js/scripts.js"></script>
 </body>

--- a/src/generate_doc.py
+++ b/src/generate_doc.py
@@ -11,6 +11,7 @@ from static import (
     version_uri,
     latest_version_uri,
     namespaces,
+    schema_info,
     schema_hierarchy,
     url_mapping
 )
@@ -148,30 +149,37 @@ for item in data.get('@graph', []):
             fair4ml_mlmodelevaluation_properties.append(formatted_property)
 
 # Extract schema.org and codemeta properties
-schema_properties = []
-codemeta_properties = []
+schema_properties = {}
+codemeta_properties = {}
 for property, val in data['@context'].items():
     if not isinstance(val, str):
         property_name = val['@id'].split(':')[-1]
         if property_name[0].islower():
             if 'schema' in val['@id'].split(':')[0]:
                 item = get_item_by_id(schemaorg_data['@graph'], val['@id'])
-                schema_properties.append(format_property(item, schemaorg_data, codemeta_data))
+                #schema_properties.append(format_property(item, schemaorg_data, codemeta_data))
+                temp_prop = format_property(item, schemaorg_data, codemeta_data)
+                schema_properties[temp_prop['property']] = temp_prop
             else:
                 codemeta_property_info = codemeta_properties_data[property_name]
                 property_json = {
-                    'property': property_name,
+                    'property': 'codemeta:' + property_name,
                     'property_url': "https://w3id.org/codemeta/"+property_name,
                     'expected_type_and_urls': list(zip([codemeta_property_info['type']], "http://schema.org/"+codemeta_property_info['type'])),
                     'description': linkify_description(codemeta_property_info["desc"])
                 }
-                codemeta_properties.append(property_json)
+                #codemeta_properties.append(property_json)
+                codemeta_properties['codemeta:' + property_name] = property_json
+
+schema_info[0]['new_properties'] = fair4ml_mlmodel_properties
+schema_info[1]['new_properties'] = fair4ml_mlmodelevaluation_properties
 
 context = {
     'description': context_desciption,
     'fair4ml_mlmodel_properties': fair4ml_mlmodel_properties,
     'fair4ml_mlmodelevaluation_properties': fair4ml_mlmodelevaluation_properties,
     'schema_hierarchy': schema_hierarchy,
+    'schema_info': schema_info,
     'schema_properties': schema_properties,
     'codemeta_properties': codemeta_properties,
     'namespaces': namespaces,

--- a/src/generate_doc.py
+++ b/src/generate_doc.py
@@ -171,6 +171,7 @@ for property, val in data['@context'].items():
                 #codemeta_properties.append(property_json)
                 codemeta_properties['codemeta:' + property_name] = property_json
 
+# Hard-coded indices shuould be fixed
 schema_info[0]['new_properties'] = fair4ml_mlmodel_properties
 schema_info[1]['new_properties'] = fair4ml_mlmodelevaluation_properties
 

--- a/src/static.py
+++ b/src/static.py
@@ -23,7 +23,7 @@ namespaces = [
     {"prefix": "owl", "url": "http://www.w3.org/2002/07/owl#"},
     {"prefix": "schema", "url": "http://schema.org/"},
     {"prefix": "codemeta", "url": "https://w3id.org/codemeta/"},
-    {"prefix": "fair4ml", "url": "https://w3id.org/fair4ml/"},
+    {"prefix": "fair4ml", "url": "https://w3id.org/fair4ml#"},
     {"prefix": "cr", "url": "http://mlcommons.org/croissant/1.0"}
 ]
 

--- a/src/static.py
+++ b/src/static.py
@@ -4,11 +4,14 @@ status = "Draft (under review)"
 version_uri = "https://w3id.org/fair4ml/0.0.1"
 latest_version_uri = "https://w3id.org/fair4ml#"
 authors = [
-    {"name": "Leyla-Jael Castro", "affiliation": "ZB MED", "affiliation_url": "https://www.zbmed.de/en/"},
-    {"name": "Daniel Garijo", "affiliation": "Universidad Politécnica de Madrid", "affiliation_url": "https://www.upm.es/"},
-    {"name": "Dietrich Rebholz-Schuhmann", "affiliation": "ZB MED", "affiliation_url": "https://www.zbmed.de/en/"},
-    {"name": "Dhwani Solanki", "affiliation": "ZB MED", "affiliation_url": "https://www.zbmed.de/en/"},
+    {"name": "Leyla Jael Castro", "affiliation": "ZB MED Information Centre for Life Sciences", "affiliation_url": "https://www.zbmed.de/en/"},
+    {"name": "Daniel Garijo", "affiliation": "Universidad Politécnica de Madrid", "affiliation_url": "https://www.upm.es/"},    
+    {"name": "Gnana Bharathy", "affiliation": "Australian Research Data Commons", "affiliation_url": "https://ardc.edu.au/"},
     {"name": "Jenifer Tabita Ciuciu-Kiss", "affiliation": "Universidad Politécnica de Madrid", "affiliation_url": "https://www.upm.es/"},
+    {"name": "Lars Eklund", "affiliation": "Uppsala University", "affiliation_url": "https://www.uu.se/en/"},
+    {"name": "Daniel S. Katz", "affiliation": "University of Illinois Urbana-Champaign", "affiliation_url": "https://illinois.edu/"},
+    {"name": "Dietrich Rebholz-Schuhmann", "affiliation": "ZB MED Information Centre for Life Sciences", "affiliation_url": "https://www.zbmed.de/en/"},
+    {"name": "Dhwani Solanki", "affiliation": "ZB MED Information Centre for Life Sciences", "affiliation_url": "https://www.zbmed.de/en/"},
     {"name": "", "affiliation": "Research Data Alliance FAIR4ML Task Force", "affiliation_url": "https://www.rd-alliance.org/groups/fair-machine-learning-fair4ml-ig/members/all-members/"}
 ]
 
@@ -28,6 +31,46 @@ schema_hierarchy = [
     {"name": "schema:Thing", "url": "http://schema.org/Thing"},
     {"name": "schema:CreativeWork", "url": "http://schema.org/CreativeWork"},
     {"name": "fair4ml:MLModel", "url": "https://github.com/RDA-FAIR4ML/FAIR4ML-schema"}
+]
+
+schema_info = [
+    {
+        "id": "MLModel",
+        "type": "fair4ml:MLModel",
+        "hierarchy": [
+            {"name": "schema:Thing", "url": "http://schema.org/Thing"},
+            {"name": "schema:CreativeWork", "url": "http://schema.org/CreativeWork"},
+            {"name": "fair4ml:MLModel", "url": "#MLModel"}
+        ],
+        "schema_reuse": [
+            "schema:archivedAt", "schema:author", "schema:citation", "schema:codeRepository", "schema:conditionsOfAccess", "schema:contributor"
+            , "schema:copyrightHolder", "schema:dateCreated", "schema:dateModified", "schema:datePublished", "schema:description"
+            , "schema:discussionUrl", "schema:distribution", "schema:funding", "schema:identifier", "schema:inLanguage"
+            , "schema:isAccessibleForFree", "schema:keywords", "schema:license", "schema:maintainer", "schema:memoryRequirements", "schema:name"
+            , "schema:operatingSystem", "schema:processorRequirements", "schema:releaseNotes", "schema:softwareHelp", "schema:softwareRequirements"
+            , "schema:storageRequirements", "schema:url", "schema:version"
+        ],
+        "codemeta_reuse": [
+            "codemeta:buildInstructions", "codemeta:developmentStatus", "codemeta:issueTracker", "codemeta:readme", "codemeta:referencePublication"
+        ]
+    },
+    {
+        "id": "MLModelEvaluation",
+        "type": "fair4ml:MLModelEvaluation",
+        "hierarchy": [
+            {"name": "schema:Thing", "url": "http://schema.org/Thing"},
+            {"name": "schema:CreativeWork", "url": "http://schema.org/CreativeWork"},
+            {"name": "fair4ml:MLModelEvaluation", "url": "#MLModelEvaluation"}
+        ],
+        "schema_reuse": [
+            "schema:author", "schema:citation", "schema:dateCreated", "schema:dateModified", "schema:datePublished", "schema:description"
+            , "schema:funding", "schema:identifier", "schema:inLanguage", "schema:keywords", "schema:license"
+            , "schema:name", "schema:url"
+        ],
+        "codemeta_reuse": [
+            "codemeta:referencePublication"
+        ]
+    }
 ]
 
 url_mapping = {

--- a/src/template.html
+++ b/src/template.html
@@ -32,6 +32,7 @@
     <div class="container min-vh-100">
         <main id="main" class="my-5">
             <h1>FAIR4ML Metadata Schema</h1>
+            <img src="img/logo.png" alt="drawing" style="width:100px;">
             <h5>Release date: {{ release_date }}</h5>
             <h5>Version: {{ version }}</h5>
             <h5>Status: {{ status }}</h5>
@@ -47,7 +48,7 @@
                         {% endif %}
                     {% endfor %}
                 </ul>
-            <h5>License: <a href="https://creativecommons.org/publicdomain/zero/1.0" target="_blank"><img src="https://img.shields.io/badge/License-https://creativecommons.org/publicdomain/zero/1.0/-blue.svg" alt="https://creativecommons.org/publicdomain/zero/1.0"></a> </h5>
+            <h5>License: <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"><img src="https://img.shields.io/badge/License-CC_by_sa-blue.svg" alt="https://creativecommons.org/licenses/by-sa/4.0/"></a> </h5>
             <h5>Download: <a href="fair4ml.jsonld" target="_blank"><img src="https://img.shields.io/badge/Format-JSON_LD-blue.svg" alt="JSON-LD"></a> <a href="https://github.com/RDA-FAIR4ML/FAIR4ML-schema" target="_blank"><img src="img/github.svg" width="3%"></a> </h5>
             <hr/>
 
@@ -71,150 +72,132 @@
                 <div class="tab-pane fade show active" id="nav-description" role="tabpanel" aria-labelledby="nav-description-tab">
                     <h3>Extending Schema.org hierarchy</h3>
                     <p>This Profile extends the Schema.org hierarchy as follows:</p>
-                    <p>
-                        {% for item in schema_hierarchy %}
-                            <a href="{{ item.url }}">{{ item.name }}</a>
+                    <ul>
+                        {% for item in schema_info %}
+                            <!--list of new classes and hierarchy-->
+                            <li>
+                                {% for hierarchy in item.hierarchy %}
+                                    <a href="{{ hierarchy.url }}">{{ hierarchy.name }}</a>
+                                    {% if not loop.last %}&gt;{% endif %}
+                                {% endfor %}
+                            </li>
+                        {% endfor %}
+                    </ul>  
+                    <hr />
+
+                    <!--START every type-->
+                    {% for item in schema_info %}
+                        <!--list of elements in each new class-->
+                        <h3 id="{{ item.id }}">Class {{ item.type }}</h3>
+                        {% for hierarchy in item.hierarchy %}
+                            <a href="{{ hierarchy.url }}">{{ hierarchy.name }}</a>
                             {% if not loop.last %}&gt;{% endif %}
                         {% endfor %}
-                    </p>
-                    <hr />
-                </div>
-                
-                <h3>fair4ml: MLModel new properties</h3>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for property in fair4ml_mlmodel_properties %}
-                                <tr>
-                                    <td class="property-column"><a href="{{ property.property_url }}">{{ property.property }}</a></td>
-                                    <td>
-                                        {% for type, url in property.expected_type_and_urls %}
-                                            <a href="{{ url }}">{{ type }}</a><br/>
-                                        {% endfor %}
-                                    </td>
-                                    <td class="description-column">{{ property.description }}</td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
 
-                <h3>fair4ml: MLModelEvaluation new properties</h3>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for property in fair4ml_mlmodelevaluation_properties %}
-                                <tr>
-                                    <td class="property-column"><a href="{{ property.property_url }}">{{ property.property }}</a></td>
-                                    <td>
-                                        {% for type, url in property.expected_type_and_urls %}
-                                            <a href="{{ url }}">{{ type }}</a><br/>
-                                        {% endfor %}
-                                    </td>
-                                    <td class="description-column">{{ property.description }}</td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-
-
-                <!-- <h3>Schema.org Profiles</h3>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Profiles</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for profile in schema_profiles %}
-                            <tr>
-                                <td class="property-column"><a href="{{ profile.profile_url }}">{{ profile.profile }}</a></td>
-                                <td class="property-column"><a href="{{ profile.profile_url }}">{{ profile.profile }}</a></td>
-                                <td class="description-column">{{ profile.description }}</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div> -->
-
-                <h3>Schema.org inherited Properties</h3>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for property in schema_properties %}
-                            <tr>
-                                <td class="property-column"><a href="{{ property.property_url }}">{{ property.property }}</a></td>
-                                <td>
-                                    {% for type, url in property.expected_type_and_urls %}
-                                        <a href="{{ url }}">{{ type }}</a><br/>
+                        <!--First new properties-->
+                        <h4>{{ item.type }} new properties</h4>                            
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for property in item.new_properties %}
+                                        <tr>
+                                            <td class="property-column"><a href="{{ property.property_url }}">{{ property.property }}</a></td>
+                                            <td>
+                                                {% for type, url in property.expected_type_and_urls %}
+                                                    <a href="{{ url }}">{{ type }}</a><br/>
+                                                {% endfor %}
+                                            </td>
+                                            <td class="description-column">{{ property.description }}</td>
+                                        </tr>
                                     {% endfor %}
-                                </td>
-                                <td class="description-column">{{ property.description }}</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <!--Second schema.org properties-->
+                        <h4>{{ item.type }} properties inherited from Schema.org</h4> 
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                {% for prop_name in item.schema_reuse %}  
+                                    {% set property = schema_properties.get(prop_name) %}  
+                                    {% if property %}
+                                        <tr>
+                                            <td class="property-column"><a href="{{ property.property_url }}">{{ property.property }}</a></td>
+                                            <td>
+                                                {% for type, url in property.expected_type_and_urls %}
+                                                    <a href="{{ url }}">{{ type }}</a><br/>
+                                                {% endfor %}
+                                            </td>
+                                            <td class="description-column">{{ property.description }}</td>
+                                        </tr>
+                                    {% endif %}
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <!--Third CodeMeta properties-->
+                        <h4>{{ item.type }} properties inherited from CodeMeta</h4> 
+                        <div class="table-responsive shadow rounded mt-4 mb-5">
+                            <table class="table table-hover table-borderless mb-0 spec-prof-table">
+                                <thead>
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Expected Type</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                {% for prop_name in item.codemeta_reuse %}  
+                                    {% set property = codemeta_properties.get(prop_name) %}  
+                                    {% if property %}
+                                        <tr>
+                                            <td class="property-column"><a href="{{ property.property_url }}">{{ property.property }}</a></td>
+                                            <td>
+                                                {% for type, url in property.expected_type_and_urls %}
+                                                    <a href="{{ url }}">{{ type }}</a><br/>
+                                                {% endfor %}
+                                            </td>
+                                            <td class="description-column">{{ property.description }}</td>
+                                        </tr>
+                                    {% endif %}
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+
+            
+                    
+                    {% endfor %}
+                    <!--END every type-->
+                    
                 </div>
 
-                <h3>Codemeta Properties</h3>
-                <div class="table-responsive shadow rounded mt-4 mb-5">
-                    <table class="table table-hover table-borderless mb-0 spec-prof-table">
-                        <thead>
-                            <tr>
-                                <th>Property</th>
-                                <th>Expected Type</th>
-                                <th>Description</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for property in codemeta_properties %}
-                            <tr>
-                                <td class="property-column"><a href="{{ property.property_url }}">{{ property.property }}</a></td>
-                                <td>
-                                    {% for type, url in property.expected_type_and_urls %}
-                                        <a href="{{ url }}">{{ type }}</a><br/>
-                                    {% endfor %}
-                                </td>
-                                <td class="description-column">{{ property.description }}</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                <p>To see a summary of the changes between this version and the previous one see the following
+                    <a href="./changelog.md">changelog</a> </p>
                 
                 <p>If you spot any errors or omissions, please file an issue in our <a
                     href="https://github.com/RDA-FAIR4ML/FAIR4ML-schema" target="_blank">GitHub</a>.</p>
+            
+            </div>   
 
-
-            </div>
         </main>
     </div>
-
     <script src="/assets/js/clipboard.min.js"></script>
     <script src="/assets/js/scripts.js"></script>
 </body>


### PR DESCRIPTION
- hasEvaluation was wrongly added to the table of new properties for MLModelEvaluation. Bug fixed
- There was a need to manually modify the html to get the second type. Enhancement added.
- License was missing from MLModelEvaluation. Added
- Schema license was wrong as extensions to schema.org should follow cc-sa