### PR TITLE
Change license to a compatible one with schema.org

### DIFF
--- a/release/0.1.0/fair4ml.jsonld
+++ b/release/0.1.0/fair4ml.jsonld
@@ -62,7 +62,7 @@
                     "@id": "https://raw.githubusercontent.com/schemaorg/schemaorg/main/data/releases/26.0/schemaorg-all-http.jsonld"
                },
                "license": {
-                    "@id": "https://creativecommons.org/publicdomain/zero/1.0/"
+                    "@id": "https://creativecommons.org/licenses/by-sa/4.0/"
                },
                "owl:versionIRI": {
                     "@id": "https://w3id.org/fair4ml/0.1.0"

--- a/release/0.1.0/index.html
+++ b/release/0.1.0/index.html
@@ -51,7 +51,7 @@
                     <li>Gnana Bharathy, <a href="https://ardc.edu.au/">Australian Research Data Commons</a></li>
                     <li><a href="https://www.rd-alliance.org/groups/fair-machine-learning-fair4ml-ig/members/all-members/">Research Data Alliance FAIR4ML Task Force</a></li>
                 </ul>
-            <h5>License: <a href="https://creativecommons.org/publicdomain/zero/1.0" target="_blank"><img src="https://img.shields.io/badge/License-https://creativecommons.org/publicdomain/zero/1.0/-blue.svg" alt="https://creativecommons.org/publicdomain/zero/1.0"></a> </h5>
+            <h5>License: <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank"><img src="https://img.shields.io/badge/License-CC_by_sa_4.0-blue.svg" alt="https://creativecommons.org/licenses/by-sa/4.0/"></a> </h5>
             <h5>Download: <a href="fair4ml.jsonld" target="_blank"><img src="https://img.shields.io/badge/Format-JSON_LD-blue.svg" alt="JSON-LD"></a> <a href="https://github.com/RDA-FAIR4ML/FAIR4ML-schema" target="_blank"><img src="img/github.svg" width="3%"></a> </h5>
             <hr/>
 


### PR DESCRIPTION
See https://schema.org/docs/terms.html, the license is CC-by-sa, we should use the same.
This PR sorts out Issue 24